### PR TITLE
Surround embeded HTML node by CDATA

### DIFF
--- a/themes/hugo-xmin-master/layouts/_default/rss.xml
+++ b/themes/hugo-xmin-master/layouts/_default/rss.xml
@@ -33,7 +33,7 @@
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
-      <content:encoded>{{ .Content | safeHTML }}</content:encoded>
+      <content:encoded><![CDATA[{{ .Content | safeHTML }}]]></content:encoded>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
See https://developer.mozilla.org/ja/docs/Web/API/CDATASection for more details about CDATA section.